### PR TITLE
Explicit dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject io.replikativ/hasch "0.3.0"
   :description "Cryptographic hashing of EDN datastructures."
-  :url "http://github.com/ghubber/hasch"
+  :url "http://github.com/replikativ/hasch"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/project.clj
+++ b/project.clj
@@ -3,14 +3,19 @@
   :url "http://github.com/replikativ/hasch"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.8.34"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
+                 [org.clojure/clojurescript "1.9.293" :scope "provided"]
                  [io.replikativ/incognito "0.2.0"]]
   :source-paths ["src"]
   :plugins [[lein-cljsbuild "1.1.2"]]
 
-  :profiles {:dev {:dependencies [[criterium "0.4.3"]]
-                   :plugins [[com.cemerick/austin "0.1.6"]]}}
+  :aliases {"all" ["with-profile" "default:+1.7:+1.8"]}
+  :profiles {:dev {:dependencies [[criterium "0.4.4"]]
+                   :plugins [[com.cemerick/austin "0.1.6"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]
+                                  [org.clojure/clojurescript "1.7.228"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [org.clojure/clojurescript "1.8.51"]]}}
 
   :jvm-opts ^:replace []
 


### PR DESCRIPTION
As per the discussion in #1, I've made a few small changes to `project.clj` to enable testing of various Clojure(script) versions.

It may be possible to get Clojure 1.6 working, but I haven't tried. This is the exception that occurs when trying to run those tests:

```
Exception in thread "main" java.io.FileNotFoundException: Could not locate cljs/compiler__init.class or cljs/compiler.clj on classpath: , compiling:(cemerick/austin.clj:1:1)
	at clojure.lang.Compiler.load(Compiler.java:7142)
	at clojure.lang.RT.loadResourceScript(RT.java:370)
	at clojure.lang.RT.loadResourceScript(RT.java:361)
	at clojure.lang.RT.load(RT.java:440)
	at clojure.lang.RT.load(RT.java:411)
	at clojure.core$load$fn__5066.invoke(core.clj:5641)
	at clojure.core$load.doInvoke(core.clj:5640)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invoke(core.clj:5446)
[...]
```

In terms of reducing dependencies, Incognito pulls in quite a bit. I'm not familiar with what Incognito does so don't know if these deps can be excluded.

```
 [io.replikativ/incognito "0.2.0"]
   [com.cognitect/transit-clj "0.8.285"]
     [com.cognitect/transit-java "0.8.311"]
       [com.fasterxml.jackson.core/jackson-core "2.3.2"]
       [commons-codec "1.10"]
       [org.msgpack/msgpack "0.6.10"]
         [com.googlecode.json-simple/json-simple "1.1.1" :exclusions [[junit]]]
         [org.javassist/javassist "3.18.1-GA"]
   [com.cognitect/transit-cljs "0.8.232"]
     [com.cognitect/transit-js "0.8.755"]
   [org.clojure/data.fressian "0.2.0"]
     [org.fressian/fressian "0.6.3"]
```