### PR TITLE
fix reflection

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
   :source-paths ["src"]
   :plugins [[lein-cljsbuild "1.1.4"]]
 
+  :global-vars {*warn-on-reflection* true}
   :aliases {"all" ["with-profile" "default:+1.7:+1.8"]}
   :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.8"]
                                   [com.cemerick/piggieback "0.2.1"]

--- a/src/hasch/base64.cljc
+++ b/src/hasch/base64.cljc
@@ -3,17 +3,14 @@
                :cljs [goog.crypt.base64])
             #?(:cljs [cljs.reader :as r])))
 
-
 (defn encode
   "Returns a base64 encoded String."
   [byte-arr]
-  #?(:clj (String. (b64/encode byte-arr) "UTF-8")
+  #?(:clj (String. ^bytes (b64/encode byte-arr) "UTF-8")
      :cljs (goog.crypt.base64.encodeByteArray byte-arr)))
-
 
 (defn decode
   "Returns a byte-array for encoded String."
-  [base64]
+  [^String base64]
   #?(:clj (b64/decode (.getBytes base64 "UTF-8"))
      :cljs (goog.crypt.base64.decodeStringToByteArray base64)))
-

--- a/src/hasch/core.cljc
+++ b/src/hasch/core.cljc
@@ -38,8 +38,8 @@
    #?(:clj
       (let [time (System/currentTimeMillis)
             secs (quot time 1000)
-            lsb (.getLeastSignificantBits uuid)
-            msb (.getMostSignificantBits uuid)
+            lsb (.getLeastSignificantBits ^java.util.UUID uuid)
+            msb (.getMostSignificantBits ^java.util.UUID uuid)
             timed-msb (bit-or (bit-shift-left secs 32)
                               (bit-and 0x00000000ffffffff msb))]
         (java.util.UUID. timed-msb lsb))
@@ -56,5 +56,3 @@
   but b64-hash is safer towards collisions."
   [val]
   (b64/encode (#?(:clj byte-array :cljs clj->js) (edn-hash val))))
-
-

--- a/src/hasch/md5.cljc
+++ b/src/hasch/md5.cljc
@@ -5,7 +5,7 @@
   #?(:clj (:import [java.security MessageDigest]
                    [java.math BigInteger])))
 
-(defn str->md5 [s]
+(defn str->md5 [^String s]
   #?(:clj
      (let [algorithm (MessageDigest/getInstance "MD5")
            raw       (.digest algorithm (.getBytes s))]
@@ -17,4 +17,3 @@
                     (.update md5-digester bytes)
                     (.digest md5-digester))]
        hashed)))
-


### PR DESCRIPTION
before this patch

```
$ lein check
[...]
Reflection warning, hasch/base64.cljc:9:11 - call to java.lang.String ctor can't be resolved.
Reflection warning, hasch/md5.cljc:11:41 - reference to field getBytes can't be resolved.
Reflection warning, hasch/core.cljc:41:17 - reference to field getLeastSignificantBits can't be resolved.
Reflection warning, hasch/core.cljc:42:17 - reference to field getMostSignificantBits can't be resolved.
```

