### PR TITLE
leverage java8 b64 encoder/decoder

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
                  [org.clojure/clojurescript "1.9.293" :scope "provided"]
-                 [io.replikativ/incognito "0.2.2"]
-                 [org.clojure/data.codec "0.1.1"]]
+                 [io.replikativ/incognito "0.2.2"]]
   :source-paths ["src"]
   :plugins [[lein-cljsbuild "1.1.4"]]
 

--- a/src/hasch/base64.cljc
+++ b/src/hasch/base64.cljc
@@ -1,16 +1,18 @@
 (ns hasch.base64
-  (:require #?(:clj [clojure.data.codec.base64 :as b64]
-               :cljs [goog.crypt.base64])
-            #?(:cljs [cljs.reader :as r])))
+  #?(:cljs (:require [goog.crypt.base64]
+                     [cljs.reader :as r]))
+  #?(:clj (:import (java.util Base64))))
 
 (defn encode
   "Returns a base64 encoded String."
   [byte-arr]
-  #?(:clj (String. ^bytes (b64/encode byte-arr) "UTF-8")
+  #?(:clj (String. (.encode (Base64/getEncoder)
+                    ^bytes byte-arr)
+           "UTF-8")
      :cljs (goog.crypt.base64.encodeByteArray byte-arr)))
 
 (defn decode
   "Returns a byte-array for encoded String."
   [^String base64]
-  #?(:clj (b64/decode (.getBytes base64 "UTF-8"))
+  #?(:clj (.decode (Base64/getDecoder) base64)
      :cljs (goog.crypt.base64.decodeStringToByteArray base64)))


### PR DESCRIPTION
This ~doubles the performance of b64 encoding/decoding by leveraging java8 `java.util.Base64`. Not sure how much it is used but it's here in case we need it. 