### PR TITLE
Exclude JS/HTML from jar file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.8.51"]]}}
 
+  :jar-exclusions [#"private" #"public"]
   :jvm-opts ^:replace []
 
   :cljsbuild


### PR DESCRIPTION
This excludes the directories "public" and "private" from the built jar.
They only contain JS and tests, so they aren't necessary.