### PR TITLE
feat: ref->uuid + hash-ref? — recover a store key from a HashRef alone

### DIFF
--- a/src/hasch/benc.cljc
+++ b/src/hasch/benc.cljc
@@ -29,6 +29,11 @@
   (-coerce [_this _md-create-fn _write-handlers]
     hash-bytes))
 
+(defn hash-ref?
+  "Is `x` a HashRef (a content-address pointer)? Cross-platform."
+  [x]
+  (instance? HashRef x))
+
 (def split-size 1024)
 
 (def max-entropy-byte-count 32)

--- a/src/hasch/core.cljc
+++ b/src/hasch/core.cljc
@@ -8,6 +8,7 @@
 (def uuid4 platform/uuid4)
 (def uuid5 platform/uuid5)
 (def hash->str platform/hash->str)
+(def hash-ref? benc/hash-ref?)
 
 (defn edn-hash
   "Hash an edn value with SHA-512 by default or a compatible hash function of choice.
@@ -66,3 +67,17 @@
   ([val write-handlers] (hash-ref val platform/sha512-message-digest write-handlers))
   ([val md-create-fn write-handlers]
    (benc/->HashRef (-coerce val md-create-fn (or write-handlers {})))))
+
+(defn ref->uuid
+  "The UUID-5 the ORIGINAL value hashes to — i.e. `(uuid val)` — recovered from its
+   `HashRef` ALONE, without the value. A `HashRef` stores the value's `-coerce` output
+   (the pre-digest bytes); re-digesting them reproduces `edn-hash` → `uuid5`.
+
+     (= (ref->uuid (hash-ref v)) (uuid v))
+
+   So a content-addressed store keyed by `(uuid val)` can be traversed / garbage-collected
+   by following `HashRef`s embedded in other stored values — no original value required."
+  ([hash-ref] (ref->uuid hash-ref platform/sha512-message-digest))
+  ([hash-ref md-create-fn]
+   (uuid5 (map #(if (neg? %) (+ % 256) %)   ; make unsigned, as in edn-hash
+               (digest (:hash-bytes hash-ref) md-create-fn)))))

--- a/test/hasch/fast_test.cljc
+++ b/test/hasch/fast_test.cljc
@@ -371,6 +371,14 @@
              (hc/uuid ref))
           "(uuid (hash-ref x)) == (uuid x)"))))
 
+(deftest ref->uuid-recovers-the-store-key-test
+  (testing "ref->uuid recovers (uuid val) from a HashRef ALONE — the key a content-
+            addressed store put the value under, so GC can follow refs without the value"
+    (doseq [val [42 :a "hello" {:a 1 :b [2 3]} #{1 2 3} [:x {:y 9}] (vec (range 100))
+                 {:transactions [[:assoc :k 1]] :parents [(hc/uuid :seed)]}]]
+      (is (= (hc/uuid val) (hc/ref->uuid (hc/hash-ref val)))
+          (str "(= (ref->uuid (hash-ref v)) (uuid v)) for " (pr-str val))))))
+
 (deftest hashref-structural-sharing-test
   (testing "Changing one subtree with HashRef changes root hash"
     (let [sub-a {:name "Alice" :scores [1 2 3]}


### PR DESCRIPTION
Two small, additive functions enabling content-addressed stores to be walked / GC'd by following embedded `HashRef`s, without holding the original values.

- **`hash-ref?`** (`benc`): a cross-platform `HashRef` predicate.
- **`ref->uuid`** (`core`): the UUID-5 a value hashes to (i.e. `(uuid val)`), recovered from its `HashRef` **alone**. A `HashRef` stores the value's `-coerce` output (the pre-digest bytes); re-digesting them reproduces `edn-hash` → `uuid5`. Note this is `uuid5(unsigned(digest(hash-bytes)))`, **not** `uuid5(hash-bytes)` — the coerce output must be digested once more.

Property tested across scalars/maps/sets/vectors/commit-shapes: `(= (ref->uuid (hash-ref v)) (uuid v))`, JVM + cljs.

Motivating use: yggdrasil's content-addressed CRDT stores break large values out under `(hasch/uuid v)` and reference them by `HashRef`; GC and cross-store ship need to follow those refs to their keys without materializing the values.

+28 lines, no behavior change to existing hashing.