### PR TITLE
Expose raw sha256/sha512 byte digests

### DIFF
--- a/src/hasch/core.cljc
+++ b/src/hasch/core.cljc
@@ -10,6 +10,13 @@
 (def hash->str platform/hash->str)
 (def hash-ref? benc/hash-ref?)
 
+;; Raw byte-level SHA digests (byte-array -> byte-array), synchronous on both
+;; platforms. These hash BYTES, not edn values (that is `edn-hash`). Exposed so
+;; the crypto layer (geheimnis HMAC/HKDF) reuses hasch's portable SHA rather
+;; than reimplementing it.
+(def sha256 platform/sha256)
+(def sha512 platform/sha512)
+
 (defn edn-hash
   "Hash an edn value with SHA-512 by default or a compatible hash function of choice.
 

--- a/src/hasch/platform.clj
+++ b/src/hasch/platform.clj
@@ -33,6 +33,20 @@
 (defn ^MessageDigest md5-message-digest []
   (MessageDigest/getInstance "md5"))
 
+;; Raw byte-level digests — the portable, synchronous SHA primitive that keyed
+;; crypto (HMAC/HKDF in geheimnis) builds on. NOT structural: these hash a
+;; byte-array, unlike edn-hash which hashes an edn value.
+
+(defn ^bytes sha256
+  "Raw SHA-256 digest of a byte-array -> byte-array."
+  [^bytes bs]
+  (.digest (MessageDigest/getInstance "SHA-256") bs))
+
+(defn ^bytes sha512
+  "Raw SHA-512 digest of a byte-array -> byte-array."
+  [^bytes bs]
+  (.digest (MessageDigest/getInstance "SHA-512") bs))
+
 (defn uuid5
   "Generates a UUID version 5 from a sha-1 hash byte sequence.
 Our hash version is coded in first 2 bits."

--- a/src/hasch/platform.cljs
+++ b/src/hasch/platform.cljs
@@ -1,5 +1,6 @@
 (ns hasch.platform
   (:require [goog.crypt]
+            [goog.crypt.Sha256]
             [goog.crypt.Sha512]
             [cljs.reader :as reader]
             [clojure.string]
@@ -89,6 +90,19 @@ Our hash version is coded in first 2 bits."
 
 (defn md5-message-digest []
   (goog.crypt.Md5.))
+
+;; Raw byte-level digests — portable, synchronous SHA (goog.crypt) that keyed
+;; crypto (HMAC/HKDF in geheimnis) builds on. Input/output are Uint8Array.
+
+(defn sha256 [bs]
+  (let [d (goog.crypt.Sha256.)]
+    (.update d bs)
+    (js/Uint8Array. (.digest d))))
+
+(defn sha512 [bs]
+  (let [d (goog.crypt.Sha512.)]
+    (.update d bs)
+    (js/Uint8Array. (.digest d))))
 
 (defn encode [magic a]
   (.concat #js [magic] a))


### PR DESCRIPTION
## Expose raw `sha256` / `sha512` byte digests

hasch already computes SHA-256/512 for structural content-addressing
(`goog.crypt` on CLJS, `java.security.MessageDigest` on JVM). This surfaces
them as **raw byte-array → byte-array** primitives:

- `hasch.core/sha256`
- `hasch.core/sha512`

Synchronous on both platforms. These hash **bytes**, distinct from `edn-hash`
which hashes an edn value.

### Why
The replikativ crypto layer (geheimnis v2 — a portable AEAD + Ed25519/X25519
façade) needs a portable, synchronous SHA to build HMAC/HKDF on. Reusing
hasch's existing digest avoids a third crypto-hash implementation, and — because
hasch's SHA is synchronous — lets **HS256 JWT verification stay synchronous in
CLJS** (only AEAD + the asymmetric curves need the async Web Crypto tier).

Keyed/secret crypto stays out of hasch: it remains an **unkeyed content-hashing**
library; HMAC and everything secret-bearing live in geheimnis.

### Changes
- `hasch.platform` (clj + cljs): raw `sha256`/`sha512`; CLJS gains a
  `goog.crypt.Sha256` require.
- `hasch.core`: public `sha256`/`sha512` re-exports.

Verified against NIST/RFC vectors via the geheimnis v2 test suite on both JVM
and Node.
