### PR TITLE
Support streaming binary hashing

### DIFF
--- a/src/hasch/platform.clj
+++ b/src/hasch/platform.clj
@@ -7,6 +7,7 @@
             [hasch.benc :refer [magics PHashCoercion -coerce
                                 digest coerce-seq xor-hashes encode-safe]])
   (:import java.io.ByteArrayOutputStream
+           java.io.InputStream
            java.nio.ByteBuffer
            java.security.MessageDigest))
 
@@ -71,6 +72,45 @@ Our hash version is coded in first 2 bits."
 
 (defn- ^bytes str->utf8 [x]
   (-> x str (.getBytes "UTF-8")))
+
+(defn ^bytes input-stream->binary-coercion
+  "Consume `in` and return exactly the same hash coercion as a byte array with
+  the same contents. The caller owns and closes the stream.
+
+  Hasch represents binaries shorter than `split-size` directly (with collision
+  escaping), and larger binaries by their digest. Buffering at most
+  `split-size` bytes lets an unknown-length stream select the same representation
+  without materializing a large value."
+  [^InputStream in md-create-fn]
+  (let [prefix (byte-array split-size)]
+    (loop [offset 0]
+      (let [read-count (.read in prefix offset (- split-size offset))]
+        (cond
+          (neg? read-count)
+          (encode (:binary magics)
+                  (encode-safe (if (zero? offset)
+                                 (byte-array 0)
+                                 (java.util.Arrays/copyOf prefix offset))
+                               md-create-fn))
+
+          (zero? read-count)
+          (recur offset)
+
+          (< (+ offset read-count) split-size)
+          (recur (+ offset read-count))
+
+          :else
+          (let [^MessageDigest md (md-create-fn)
+                buffer (byte-array (* 1024 1024))]
+            (.update md prefix)
+            (loop []
+              (let [n (.read in buffer)]
+                (cond
+                  (neg? n) (encode (:binary magics) (.digest md))
+                  (zero? n) (recur)
+                  :else (do
+                          (.update md buffer 0 n)
+                          (recur)))))))))))
 
 (extend-protocol PHashCoercion
   java.lang.Boolean
@@ -165,26 +205,14 @@ Our hash version is coded in first 2 bits."
                                                     md-create-fn)
                                            (seq this)))))
 
-  ;; not ideal, InputStream might be more flexible
-  ;; file is used due to length knowledge
+  java.io.InputStream
+  (-coerce [in md-create-fn _write-handlers]
+    (input-stream->binary-coercion in md-create-fn))
+
   java.io.File
-  (-coerce [f md-create-fn write-handlers]
-    (let [^MessageDigest md (md-create-fn)
-          len (.length f)]
-      (with-open [fis (java.io.FileInputStream. f)]
-        (encode (:binary magics)
-                ;; support default split-size behaviour transparently
-                (if (< len split-size)
-                  (let [ba (with-open [out (java.io.ByteArrayOutputStream.)]
-                             (clojure.java.io/copy fis out)
-                             (.toByteArray out))]
-                    (encode-safe ba md-create-fn))
-                  (let [ba (byte-array (* 1024 1024))]
-                    (loop [size (.read fis ba)]
-                      (if (neg? size) (.digest md)
-                          (do
-                            (.update md ba 0 size)
-                            (recur (.read fis ba))))))))))))
+  (-coerce [f md-create-fn _write-handlers]
+    (with-open [in (java.io.FileInputStream. f)]
+      (input-stream->binary-coercion in md-create-fn))))
 
 (extend (Class/forName "[B")
   PHashCoercion

--- a/test/hasch/api_test.cljc
+++ b/test/hasch/api_test.cljc
@@ -5,7 +5,8 @@
             [hasch.hex :as hex]
             [hasch.platform :refer [uuid5 hash->str #?(:cljs utf8)]]
             [incognito.base :as ic]
-            [clojure.test :as t :refer (is deftest testing)]))
+            [clojure.test :as t :refer (is deftest testing)])
+  #?(:clj (:import [java.io ByteArrayInputStream FilterInputStream])))
 
 #?(:cljs (def byte-array into-array))
 
@@ -101,6 +102,27 @@
                edn-hash
                uuid5)
            #uuid "386eabb0-8adc-52a2-a715-5a74c9197646"))))
+
+#?(:clj
+   (deftest input-stream-binary-hashing
+     (testing "InputStreams hash identically to in-memory byte arrays"
+       (doseq [size [0 1 17 1023 1024 1025 65537]]
+         (let [bytes (byte-array (map unchecked-byte (take size (cycle (range 251)))))]
+           (with-open [in (ByteArrayInputStream. bytes)]
+             (is (= (edn-hash bytes) (edn-hash in)) (str "size " size)))
+           (with-open [in (ByteArrayInputStream. bytes)]
+             (is (= (uuid bytes) (uuid in)) (str "UUID size " size))))))
+
+     (testing "short reads do not affect the hash"
+       (let [bytes (byte-array (map unchecked-byte (take 8193 (cycle (range 251)))))]
+         (with-open [source (ByteArrayInputStream. bytes)
+                     in (proxy [FilterInputStream] [source]
+                          (read
+                            ([] (proxy-super read))
+                            ([buffer] (proxy-super read buffer))
+                            ([buffer offset length]
+                             (proxy-super read buffer offset (min 7 length)))))]
+           (is (= (uuid bytes) (uuid in))))))))
 
 (deftest hash-stringification
   (testing "Stringification."


### PR DESCRIPTION
## Summary
- hash JVM InputStreams with the same content identity as byte arrays
- preserve stream ownership by consuming without closing
- cover split boundaries, short reads, and representative payload sizes

## Verification
- 58 tests, 142 assertions, 0 failures