### PR TITLE
feat: hash float[]/double[] (JVM) and Float32/Float64Array (JS)

### DIFF
--- a/src/hasch/benc.cljc
+++ b/src/hasch/benc.cljc
@@ -8,7 +8,8 @@
 (defprotocol PHashCoercion
   (-coerce [this md-create-fn write-handlers]))
 
-;; changes break hashes!
+;; changes break hashes! (adding a NEW key is safe — existing values keep their
+;; magic byte; only reassigning an existing key would break prior hashes.)
 (def magics {:nil (byte 0)
              :boolean (byte 1)
              :number (byte 2)
@@ -22,7 +23,13 @@
              :map (byte 10)
              :set (byte 11)
              :literal (byte 12)
-             :binary (byte 13)})
+             :binary (byte 13)
+             ;; primitive numeric arrays, coerced from their canonical IEEE-754
+             ;; big-endian bytes so a JVM float[]/double[] and a JS
+             ;; Float32Array/Float64Array of equal values hash identically. A
+             ;; distinct magic keeps them from colliding with :binary or :vector.
+             :float-array (byte 14)
+             :double-array (byte 15)})
 
 (defrecord HashRef [hash-bytes]
   PHashCoercion

--- a/src/hasch/platform.clj
+++ b/src/hasch/platform.clj
@@ -219,6 +219,37 @@ Our hash version is coded in first 2 bits."
   {:-coerce (fn [^bytes this md-create-fn write-handlers]
               (encode (:binary magics) (encode-safe this md-create-fn)))})
 
+;; Primitive numeric arrays hash from their canonical IEEE-754 *big-endian*
+;; bytes. Big-endian is chosen so the byte layout is fixed across platforms:
+;; the same 4-byte float32 / 8-byte float64 bit-patterns are produced by a JS
+;; Float32Array/Float64Array (see platform.cljs), so equal-valued arrays hash
+;; identically on the JVM and in the browser. (Coercing via the numbers' string
+;; form would not be portable — a JVM float 0.1 prints "0.1" but the same
+;; float32 widened to a JS number prints "0.10000000149011612".)
+(defn ^bytes float-array->bytes [^floats a]
+  (let [n (alength a)
+        bb (java.nio.ByteBuffer/allocate (* 4 n))]      ; big-endian by default
+    (dotimes [i n] (.putFloat bb (aget a i)))
+    (.array bb)))
+
+(defn ^bytes double-array->bytes [^doubles a]
+  (let [n (alength a)
+        bb (java.nio.ByteBuffer/allocate (* 8 n))]
+    (dotimes [i n] (.putDouble bb (aget a i)))
+    (.array bb)))
+
+(extend (Class/forName "[F")
+  PHashCoercion
+  {:-coerce (fn [^floats this md-create-fn write-handlers]
+              (encode (:float-array magics)
+                      (encode-safe (float-array->bytes this) md-create-fn)))})
+
+(extend (Class/forName "[D")
+  PHashCoercion
+  {:-coerce (fn [^doubles this md-create-fn write-handlers]
+              (encode (:double-array magics)
+                      (encode-safe (double-array->bytes this) md-create-fn)))})
+
 (comment
   (require '[clojure.java.io :as io])
   (def foo (io/file "/tmp/foo"))

--- a/src/hasch/platform.cljs
+++ b/src/hasch/platform.cljs
@@ -110,6 +110,25 @@ Our hash version is coded in first 2 bits."
 (defn- str->utf8 [x]
   (-> x str utf8))
 
+;; Primitive numeric arrays hash from their canonical IEEE-754 *big-endian*
+;; bytes (DataView with littleEndian=false), matching the JVM's ByteBuffer in
+;; platform.clj so an equal-valued Float32Array/float[] (and Float64Array/
+;; double[]) hash identically across platforms. Returns a plain JS array of
+;; 0-255 byte values, the shape encode-safe already consumes for Uint8Array.
+(defn- typed-array->be-bytes [typed-arr elem-bytes set-fn]
+  (let [n (.-length typed-arr)
+        buf (js/ArrayBuffer. (* elem-bytes n))
+        dv (js/DataView. buf)]
+    (dotimes [i n]
+      (set-fn dv (* elem-bytes i) (aget typed-arr i) false)) ; false = big-endian
+    (js/Array.prototype.slice.call (js/Uint8Array. buf))))
+
+(defn- float32-array->bytes [a]
+  (typed-array->be-bytes a 4 (fn [dv off v _le] (.setFloat32 dv off v _le))))
+
+(defn- float64-array->bytes [a]
+  (typed-array->be-bytes a 8 (fn [dv off v _le] (.setFloat64 dv off v _le))))
+
 (extend-protocol PHashCoercion
   nil
   (-coerce [this md-create-fn write-handlers]
@@ -172,6 +191,12 @@ Our hash version is coded in first 2 bits."
 
           (instance? js/Uint8Array this)
           (encode (:binary magics) (encode-safe (js/Array.prototype.slice.call this) md-create-fn))
+
+          (instance? js/Float32Array this)
+          (encode (:float-array magics) (encode-safe (float32-array->bytes this) md-create-fn))
+
+          (instance? js/Float64Array this)
+          (encode (:double-array magics) (encode-safe (float64-array->bytes this) md-create-fn))
 
           :else
           (throw (ex-info "Cannot hash unknown type, you can extend PHashCoercion protocol for:"

--- a/test/hasch/api_test.cljc
+++ b/test/hasch/api_test.cljc
@@ -86,6 +86,23 @@
                         :clj (byte-array [1 2 3 42 149])))
            '(135 209 248 171 162 90 41 221 173 216 64 218 222 93 242 60 243 5 190 153 101 194 74 130 55 184 84 148 167 94 210 250 140 211 6 234 221 25 113 83 153 75 180 4 194 163 178 197 243 126 27 172 248 169 161 90 102 172 160 98 249 32 42 157)))))
 
+(deftest primitive-numeric-array-coercion
+  (testing "float[]/double[] (JVM) and Float32Array/Float64Array (JS) coerce to
+            fixed, cross-platform-identical hashes via canonical IEEE-754
+            big-endian bytes. These literals were produced on the JVM; the same
+            .cljc test runs under node-test, so its passing there proves the two
+            platforms agree byte-for-byte."
+    (let [fa #?(:clj (float-array [1.5 2.5 3.5])  :cljs (js/Float32Array. #js [1.5 2.5 3.5]))
+          da #?(:clj (double-array [1.5 2.5 3.5]) :cljs (js/Float64Array. #js [1.5 2.5 3.5]))]
+      (is (= (edn-hash fa)
+             '(195 249 30 210 135 154 193 234 102 80 245 129 156 245 4 138 46 245 122 2 178 238 81 79 22 101 160 158 40 230 251 20 135 241 245 28 13 172 48 206 21 23 20 185 169 117 22 222 224 201 223 39 199 69 224 5 139 243 103 122 220 229 89 65)))
+      (is (= (edn-hash da)
+             '(209 200 247 227 171 49 22 207 125 108 221 170 200 21 230 156 85 20 198 158 31 179 213 33 248 205 125 182 8 65 192 243 183 22 21 118 148 223 173 143 89 24 40 229 3 105 8 224 176 8 73 65 56 39 215 138 57 104 41 84 76 162 187 205)))
+      ;; a float[] and a double[] of equal values differ (byte width + magic),
+      ;; and both differ from the boxed vector of the same numbers
+      (is (not= (edn-hash fa) (edn-hash da)))
+      (is (not= (edn-hash fa) (edn-hash [1.5 2.5 3.5]))))))
+
 (deftest padded-coercion
   (testing "Padded xor coercion for commutative collections."
     (is (= (map byte


### PR DESCRIPTION
## Problem

hasch cannot hash a primitive numeric array:

```clojure
(hasch.core/uuid (float-array [1.0 2.0 3.0]))
;; => IllegalArgumentException: No implementation of method: :-coerce ...
```

`PHashCoercion` is extended for `[B` (byte-array) but not `[F`/`[D`, and the cljs `default` branch handles `Uint8Array` but not `Float32Array`/`Float64Array`.

This surfaced in datahike: secondary-index values are content-addressed via `hasch/uuid` (e.g. a `:db.secondary/only` embedding attribute stores a hasch hash in the primary index). A float/double-array embedding therefore couldn't be stored at all.

## Fix

Coerce primitive numeric arrays from their **canonical IEEE-754 big-endian bytes**, under two new magic tags (`:float-array` 14, `:double-array` 15).

**Why big-endian, not the numbers' string form:** portability. The byte layout is then identical on the JVM (`ByteBuffer`) and in JS (`DataView`, `littleEndian=false`), so an equal-valued `float[]` / `Float32Array` (and `double[]` / `Float64Array`) hash **byte-for-byte the same across platforms**. Coercing via `.toString` would not be portable — a JVM `float` `0.1` prints `"0.1"`, but the same float32 widened to a JS `number` prints `"0.10000000149011612"`.

**Backwards compatible:** adding magic *keys* leaves every existing value on its existing tag, so prior hashes are unchanged. Distinct tags also keep `float[]`, `double[]`, `byte[]`, and boxed vectors from colliding.

## Validation

- New `primitive-numeric-array-coercion` test in the cross-platform `api_test.cljc` asserts fixed hash literals (generated on the JVM). Because that same `.cljc` test **also runs under `node-test`**, its passing on cljs proves the JVM and browser agree byte-for-byte — the property this PR is really about.
- JVM (kaocha): **59 tests, 146 assertions, 0 failures**.
- cljs (shadow node-test): **57 tests, 118 assertions, 0 failures**.
- Deterministic; `float[]` ≠ `double[]` ≠ boxed vector of the same numbers.

Found while enabling vector-embedding storage in datahike (Proximum secondary index) over a geschichte repository.